### PR TITLE
Ensure tags are deleted only once during cleanup

### DIFF
--- a/src/CachingFramework.Redis/Providers/RedisCacheProvider.cs
+++ b/src/CachingFramework.Redis/Providers/RedisCacheProvider.cs
@@ -1261,6 +1261,7 @@ namespace CachingFramework.Redis.Providers
                     if (toRemove.Count > 0)
                     {
                         db.SetRemove(tag, toRemove.ToArray());
+                        toRemove.Clear();
                     }
                 }
             }
@@ -1323,6 +1324,7 @@ namespace CachingFramework.Redis.Providers
                     if (toRemove.Count > 0)
                     {
                         await db.SetRemoveAsync(tag, toRemove.ToArray()).ForAwait();
+                        toRemove.Clear();
                     }
                 }
             }


### PR DESCRIPTION
When enumerating over the tags passed into the method GetTaggedItemsWithCleanup and its Async companion, the set of tags to remove was not cleared after a tag delete call to Redis, causing subsequent loop enumerations to call SetRemove on Redis with set members from previous iterations.